### PR TITLE
Spec Validation Against AWS Cognito - maximum length is 20 characters

### DIFF
--- a/functionality/users_and_access/identity_and_access_management.md
+++ b/functionality/users_and_access/identity_and_access_management.md
@@ -24,7 +24,6 @@ must be unique within the system including the nicknames of users that have been
 The user has to option to specify a password:
 - the password must meet these criteria:
  - minimum length is 8 characters
- - maximum length is 20 characters
  - must include a numeric character and a special character
  - consists only of these characters: a-z A-Z 0-9 [TBD: special characters]
 - the user has the option the store the password on the device and therefore not having to


### PR DESCRIPTION
While creating a User Pool in AWS Cognito, we can only set minimum characters and there is no option to set maximum characters in AWS Cognito.
Existing Spec: maximum length is 20 characters
Request for change: 1. Can we remove this spec as we don't have the option to set it in AWS Cognito? 2. We can do this validation from front-end as soon as User clicks on Register/Sign Up.