### PR TITLE
Spec validation against AWS Cognito - verification link validity

### DIFF
--- a/functionality/users_and_access/identity_and_access_management.md
+++ b/functionality/users_and_access/identity_and_access_management.md
@@ -13,7 +13,6 @@ must be a numeric primary key).
 The system shall send an e-mail to the specified e-mail address containing a url that the
 user should click to confirm is ownership of the e-mail account.
 - Clicking the link will take the user into the system where he can set a password.
-- The verification link is valid for 24 hours. After this period the user is prompted to re-apply.
 - A verification link can only be used one time.
 
 ### Step 3: Select nickname and password


### PR DESCRIPTION
Existing Spec - The verification link is valid for 24 hours. After this period the user is prompted to re-apply.
Request for change - 1. Remove the spec because there is no info about the validity of the verification link/code in AWS Cognito doc. refer https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pool-settings-message-customizations.html. I assume there is no validity at all for verification link/code in AWS Cognito.